### PR TITLE
Clarify, restructure, and extend measurement metadata

### DIFF
--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -633,16 +633,21 @@ constraints vary across devices, applications, and deployment environments.
 To support reproducibility and enable confidence analysis, each measurement must
 be accompanied by the following metadata:
 
-* Description of the measurement path, including the endpoints (source and destination), network segments traversed, measurement points (if applicable), and direction (uplink, downlink, or bidirectional)
-* Timestamp of first sample
-* Total duration of the sampling period
+* Measurement method (e.g., TWAMP, STAMP, ...)
+* Description of the measurement path, including
+  * Endpoints (source and destination)
+  * Network segments traversed
+  * Measurement points (if applicable)
+  * Direction (uplink, downlink, or bidirectional)
+* Timestamp of first sample (e.g., in the format used in TWAMP {{?RFC5357}}{{?RFC8877}})
+* Total duration of the sampling period (in milliseconds)
 * Number of samples collected
-* Sampling method, including:
+* Sampling method, including but not limited to:
   * Cyclic: One sample every N milliseconds (specify N)
   * Burst: X samples every N milliseconds (specify X and N)
   * Passive: Opportunistic sampling of live traffic (non-uniform intervals)
 
-These metadata elements are essential for interpreting the precision and
+These metadata elements are required for interpreting the precision and
 reliability of the measurements. As demonstrated in {{QoOSimStudy}}, low
 sampling frequencies and short measurement durations can lead to misleadingly
 optimistic or imprecise QoO scores.

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -644,7 +644,7 @@ be accompanied by the following metadata:
     * Cyclic: One sample every N milliseconds (specify N)
     * Burst: X samples every N milliseconds (specify X and N)
     * Passive: Opportunistic sampling of live traffic (non-uniform intervals)
-* Description of the measurement path, including
+* Description of the measurement path, including:
   * Endpoints (source and destination)
   * Network segments traversed
   * Measurement points (if applicable)

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -635,7 +635,7 @@ be accompanied by the following metadata:
 
 * Description of the measurement method, including:
   * Standard name (if applicable) or reference
-  * Measurement class (Active, Passive, Hybrid {{RFC7799}})
+  * Measurement class (Active, Passive, or Hybrid) {{RFC7799}}
   * Protocol layer used for measurements (ICMP, TCP, UDP, ...)
 * Measurement configuration, including
   * Probe packet size  (if applicable)

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -636,7 +636,7 @@ be accompanied by the following metadata:
 * Description of the measurement method, including:
   * Standard name (if applicable) or reference
   * Measurement class (Active, Passive, Hybrid {{RFC7799}})
-  * Protocol layer used for measurements (e.g., ICMP, TCP, UDP, ...)
+  * Protocol layer used for measurements (ICMP, TCP, UDP, ...)
 * Measurement configuration, including
   * Probe packet size  (if applicable)
   * Traffic class of probed traffic

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -649,7 +649,7 @@ be accompanied by the following metadata:
   * Network segments traversed
   * Measurement points (if applicable)
   * Direction (two-way, one-way uplink, one-way downlink)
-* Description of the measurement duration, including
+* Description of the measurement duration, including:
   * Timestamp of first sample (e.g., in the format used in TWAMP {{?RFC5357}}{{?RFC8877}})
   * Total duration of the sampling period (in milliseconds)
   * Number of samples collected

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -633,7 +633,7 @@ constraints vary across devices, applications, and deployment environments.
 To support reproducibility and enable confidence analysis, each measurement must
 be accompanied by the following metadata:
 
-* Description of the measurement method, including
+* Description of the measurement method, including:
   * Standard name (if applicable) or reference
   * Measurement class (Active, Passive, Hybrid {{RFC7799}})
   * Protocol layer used for measurements (e.g., ICMP, TCP, UDP, ...)

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -637,7 +637,7 @@ be accompanied by the following metadata:
   * Standard name (if applicable) or reference
   * Measurement class (Active, Passive, or Hybrid) {{RFC7799}}
   * Protocol layer used for measurements (ICMP, TCP, UDP, ...)
-* Measurement configuration, including
+* Measurement configuration, including:
   * Probe packet size  (if applicable)
   * Traffic class of probed traffic
   * Sampling method, including but not limited to

--- a/draft-ietf-ippm-qoo.md
+++ b/draft-ietf-ippm-qoo.md
@@ -633,19 +633,26 @@ constraints vary across devices, applications, and deployment environments.
 To support reproducibility and enable confidence analysis, each measurement must
 be accompanied by the following metadata:
 
-* Measurement method (e.g., TWAMP, STAMP, ...)
+* Description of the measurement method, including
+  * Standard name (if applicable) or reference
+  * Measurement class (Active, Passive, Hybrid {{RFC7799}})
+  * Protocol layer used for measurements (e.g., ICMP, TCP, UDP, ...)
+* Measurement configuration, including
+  * Probe packet size  (if applicable)
+  * Traffic class of probed traffic
+  * Sampling method, including but not limited to
+    * Cyclic: One sample every N milliseconds (specify N)
+    * Burst: X samples every N milliseconds (specify X and N)
+    * Passive: Opportunistic sampling of live traffic (non-uniform intervals)
 * Description of the measurement path, including
   * Endpoints (source and destination)
   * Network segments traversed
   * Measurement points (if applicable)
-  * Direction (uplink, downlink, or bidirectional)
-* Timestamp of first sample (e.g., in the format used in TWAMP {{?RFC5357}}{{?RFC8877}})
-* Total duration of the sampling period (in milliseconds)
-* Number of samples collected
-* Sampling method, including but not limited to:
-  * Cyclic: One sample every N milliseconds (specify N)
-  * Burst: X samples every N milliseconds (specify X and N)
-  * Passive: Opportunistic sampling of live traffic (non-uniform intervals)
+  * Direction (two-way, one-way uplink, one-way downlink)
+* Description of the measurement duration, including
+  * Timestamp of first sample (e.g., in the format used in TWAMP {{?RFC5357}}{{?RFC8877}})
+  * Total duration of the sampling period (in milliseconds)
+  * Number of samples collected
 
 These metadata elements are required for interpreting the precision and
 reliability of the measurements. As demonstrated in {{QoOSimStudy}}, low


### PR DESCRIPTION
This PR addresses issue #29 by:

- Clarifying the required measurement metadata by adding units and references
- Extending the required measurement metadata to enable broader utility
- Restructuring and grouping the required measurement metadata